### PR TITLE
Add run-unit-tests step

### DIFF
--- a/infra/cloudbuild.yaml
+++ b/infra/cloudbuild.yaml
@@ -1,4 +1,8 @@
 steps:
+  - id: 'run-unit-tests'
+    name: node:20
+    entrypoint: bash
+    args: ['-c', 'npm ci && npm test -- --ci']
   - id: 'tf-init'
     name: hashicorp/terraform:1.8
     entrypoint: terraform


### PR DESCRIPTION
## Summary
- run unit tests in cloud build before infrastructure steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e0c6a68e4832a951b9a2efee14af2