### PR TITLE
Add Jest tests for math.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,8 @@ infra/*.json
 gcp-sa-key.json
 gcp-sa-key.b64
 
-
 # ─ Terraform ─
 .terraform/
 infra/.terraform/
 *.tfstate*
-*.tfstate.*
+node_modules/

--- a/src/math.js
+++ b/src/math.js
@@ -1,0 +1,15 @@
+function add(a, b) {
+  if (typeof a !== 'number' || typeof b !== 'number') {
+    throw new TypeError('Inputs must be numbers');
+  }
+  return a + b;
+}
+
+function sub(a, b) {
+  if (typeof a !== 'number' || typeof b !== 'number') {
+    throw new TypeError('Inputs must be numbers');
+  }
+  return a - b;
+}
+
+module.exports = { add, sub };

--- a/tests/math.test.js
+++ b/tests/math.test.js
@@ -1,0 +1,37 @@
+const { add, sub } = require('../src/math');
+
+describe('add', () => {
+  it('adds two positive integers', () => {
+    expect(add(2, 3)).toBe(5);
+  });
+
+  it('adds positive and negative numbers', () => {
+    expect(add(5, -2)).toBe(3);
+  });
+
+  it('handles zero edge-case', () => {
+    expect(add(0, 4)).toBe(4);
+  });
+
+  it('throws TypeError for non-number inputs', () => {
+    expect(() => add('a', 1)).toThrow(TypeError);
+  });
+});
+
+describe('sub', () => {
+  it('subtracts two positive integers', () => {
+    expect(sub(5, 2)).toBe(3);
+  });
+
+  it('subtracts positive and negative numbers', () => {
+    expect(sub(5, -2)).toBe(7);
+  });
+
+  it('handles zero edge-case', () => {
+    expect(sub(0, 5)).toBe(-5);
+  });
+
+  it('throws TypeError for non-number inputs', () => {
+    expect(() => sub(1, 'b')).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## Summary
- implement simple math helpers
- add Jest unit tests for add and sub covering edge cases

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e0b58ba58832aa607895d9dd3afc1