### PR TITLE
Add Node HTTP server and update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ RUN npm ci --omit=dev
 # 3. ソースコードをコピー
 COPY . .
 
-# 4. サンプルとして math.js を実行
-CMD ["node", "src/math.js"]
+# 4. 起動コマンドを server.js に変更
+CMD ["node", "src/server.js"]

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,13 @@
+const http = require('http');
+const port = process.env.PORT || 8080;
+
+const handler = (req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('\uD83D\uDC4B Picca is alive!\n');
+};
+
+const server = http.createServer(handler);
+
+server.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add a minimal builtin HTTP server
- update Dockerfile to run server

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e91b75480832a8a88f45c08ae5cd6