### PR TITLE
feat: integrate Secret Manager into CI/CD and Next.js (T-3)

### DIFF
--- a/app/api/secret-check/route.ts
+++ b/app/api/secret-check/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({
+    db: process.env.DB_PASSWORD ?? null,
+    key: !!process.env.API_KEY        // true/false だけ返す
+  });
+}

--- a/app/env.local.example
+++ b/app/env.local.example
@@ -1,0 +1,2 @@
+DB_PASSWORD=
+API_KEY=

--- a/infra/cloudbuild.yaml
+++ b/infra/cloudbuild.yaml
@@ -5,6 +5,9 @@ availableSecrets:
     - versionName: "projects/$PROJECT_ID/secrets/DB_PASSWORD/versions/latest"
       env: "DB_PASSWORD"
 
+    - versionName: "projects/$PROJECT_ID/secrets/API_KEY/versions/latest"
+      env: "API_KEY"
+
 substitutions:
   _TF_ACTION: 'plan'
   _REGION: 'asia-northeast1'
@@ -56,7 +59,7 @@ steps:
           --image gcr.io/$PROJECT_ID/$_SERVICE:$SHORT_SHA \
           --region $_REGION \
           --platform managed \
-          --set-secrets=DB_PASSWORD=DB_PASSWORD:latest \
+          --set-secrets=DB_PASSWORD=DB_PASSWORD:latest,API_KEY=API_KEY:latest \
           --allow-unauthenticated \
           --quiet
 


### PR DESCRIPTION
### 概要
- GCP Secret Manager から `DB_PASSWORD` と `API_KEY` を取得し、Cloud Run の環境変数として注入するようにしました
- Next.js 側に `/api/secret-check` エンドポイントを追加し、環境変数が正しく読み込まれているか確認できるように実装

### 変更点
1. **infra/cloudbuild.yaml**  
   - `--update-secrets` フラグで `DB_PASSWORD` と `API_KEY` をバインドするように設定
2. **app/env.local.example**  
   - 環境変数の雛形として `DB_PASSWORD`・`API_KEY` を追加
3. **app/api/secret-check/route.ts**  
   - Secret の値を返却するテスト用エンドポイントを追加

### 確認手順
1. このブランチをマージ後、Cloud Build が自動でデプロイされるのを待つ  
2. 下記 URL にアクセスして以下の JSON が返ることを確認  
