### PR TITLE
feat(ml): Python ML 推論サービス追加

### DIFF
--- a/cloudbuild-ml-py.yaml
+++ b/cloudbuild-ml-py.yaml
@@ -1,0 +1,13 @@
+﻿steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'Build-ML-Py'
+    dir: 'services/ml-py'
+    args:
+      - build
+      - -t
+      - '-docker.pkg.dev//picca/picca-ml-py-stg:latest'
+      - '.'
+images:
+  - '-docker.pkg.dev//picca/picca-ml-py-stg:latest'
+substitutions:
+  _REGION: asia-northeast1

--- a/services/ml-py/Dockerfile
+++ b/services/ml-py/Dockerfile
@@ -1,0 +1,13 @@
+# services/ml-py/Dockerfile
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+COPY main.py .
+
+RUN pip install --no-cache-dir fastapi uvicorn[standard]
+EXPOSE 8080
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/ml-py/main.py
+++ b/services/ml-py/main.py
@@ -1,0 +1,9 @@
+# services/ml-py/main.py
+from fastapi import FastAPI, Request, HTTPException
+
+app = FastAPI()
+
+@app.post("/predict")
+async def predict(_: Request):
+    # ↳ Task-6 で本物のモデルに置換
+    return {"score": 0.87}


### PR DESCRIPTION
## 概要
- `services/ml-py` に FastAPI ベースの `/predict` モック実装を追加  
- 同ディレクトリに Dockerfile を配置し、ローカル・Cloud Build でビルド可能に  
- `cloudbuild-ml-py.yaml` で ML サービスの CI/CD を設定  
- `infra/ml_py_stg.tf` によって `picca-ml-py-stg` Cloud Run サービスを Terraform 管理下に  
- Next.js 側 `app/api/predict/route.ts` で ML サービスをプロキシ

## 確認手順
1. Cloud Build が成功し、Artifact Registry に `picca-ml-py-stg:latest` が登録される  
2. `terraform apply` 後に Cloud Run ステージング上で `picca-ml-py-stg` が立ち上がる  
3. 以下コマンドで `{ "score":0.87 }` が返ってくる  
   ```bash
   curl -X POST https://<next-stg-domain>/api/predict \
        -H 'Content-Type: application/json' \
        -d '{}'
