### PR TITLE
feat: add model storage bucket

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,23 @@
+# Infrastructure
+
+This directory contains Terraform configuration for the picca project.
+
+## Model Storage Bucket
+
+The `model_storage.tf` file provisions a Google Cloud Storage bucket named
+`picca-models` to store machine learning models. The bucket is created in the
+region defined by the `region` variable and uses the `NEARLINE` storage class.
+A lifecycle rule moves objects to the `COLDLINE` storage class after 90 days.
+
+Access to objects is granted to the service account
+`ml-py-stg-sa@<project>.iam.gserviceaccount.com` with the
+`roles/storage.objectViewer` role.
+
+## Quick start
+
+```bash
+terraform init
+terraform plan
+terraform apply
+terraform destroy
+```

--- a/infra/iam_model_storage.tf
+++ b/infra/iam_model_storage.tf
@@ -1,0 +1,5 @@
+resource "google_storage_bucket_iam_member" "model_viewer" {
+  bucket = google_storage_bucket.model_storage.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:ml-py-stg-sa@${var.project}.iam.gserviceaccount.com"
+}

--- a/infra/model_storage.tf
+++ b/infra/model_storage.tf
@@ -1,0 +1,18 @@
+resource "google_storage_bucket" "model_storage" {
+  name                        = "picca-models"
+  project                     = var.project
+  location                    = var.region
+  storage_class               = "NEARLINE"
+  uniform_bucket_level_access = true
+
+  lifecycle_rule {
+    condition {
+      age = 90
+    }
+
+    action {
+      type          = "SetStorageClass"
+      storage_class = "COLDLINE"
+    }
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "Name of the GCS bucket for ML models"
+  value       = google_storage_bucket.model_storage.name
+}
+
+output "bucket_url" {
+  description = "gs:// URI of the ML model bucket"
+  value       = "gs://${google_storage_bucket.model_storage.name}"
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,8 @@
+variable "project" {
+  type = string
+}
+
+variable "region" {
+  type    = string
+  default = "asia-northeast1"
+}


### PR DESCRIPTION
## Summary
- create GCS bucket for ML models with lifecycle rule
- grant object viewer role to ml service account
- expose bucket details via output variables
- document infrastructure setup with quick start commands

## Testing
- `npm install`
- `npm test`
- `terraform fmt -recursive infra`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6883832146ec832ab0b72ad270182384