### PR TITLE
Fix ml_export workflow

### DIFF
--- a/.github/workflows/ml_export.yml
+++ b/.github/workflows/ml_export.yml
@@ -16,57 +16,36 @@ jobs:
   export:
     runs-on: ubuntu-latest
     steps:
-
-      # 👉 1. リポジトリをチェックアウト
+      # 1) Checkout
       - uses: actions/checkout@v4
 
-      # 👉 2. GCP 認証
+      # 2) **Auth step – 必須**
       - id: auth
         uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GCP_SA_JSON }}
 
-      # 👉 3. gcloud / gsutil をインストール
+      # 3) gcloud / gsutil setup
       - uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
-      # 👉 4. Python 依存インストール
+      # 4) Python deps
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-      - uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_JSON }}
-          export_default_credentials: true
-
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
           pip install torch onnx onnxruntime
 
-
-      # 👉 5. スクリプト実行 & アップロード
+      # 5) Export & upload
       - name: Prepare scripts
         run: chmod +x scripts/hash_model.sh
 
       - name: Export ONNX
         run: python scripts/export_onnx.py --ckpt ${{ inputs.ckpt_path }} --out model.onnx
 
-      - name: Hash
-        run: bash scripts/hash_model.sh model.onnx
-
-
-      - name: Prepare scripts
-        run: chmod +x scripts/hash_model.sh
-      - name: Export ONNX
-        run: python scripts/export_onnx.py --ckpt ${{ inputs.ckpt_path }} --out model.onnx
       - name: Hash
         run: bash scripts/hash_model.sh model.onnx
 


### PR DESCRIPTION
## Summary
- clean up ml_export workflow
- remove deprecated auth options and duplicate steps

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889769cc440832ab6c9d6ffc1d0f09d