### PR TITLE
chore(iac): add tf-apply step on Cloud Build

### DIFF
--- a/infra/ci.tf
+++ b/infra/ci.tf
@@ -35,3 +35,41 @@ resource "google_cloudbuild_trigger" "main-branch-trigger" {
 
   filename = "infra/cloudbuild.yaml"
 }
+
+# Trigger for infrastructure changes via iac/ branches
+resource "google_cloudbuild_trigger" "iac-branch-trigger" {
+  provider = google-beta
+  project  = local.project_id
+  location = local.region
+  name     = "iac-branch-trigger"
+
+  service_account = "projects/${local.project_id}/serviceAccounts/terraform-sa@${local.project_id}.iam.gserviceaccount.com"
+
+  repository_event_config {
+    repository = google_cloudbuildv2_repository.picca_repository.id
+    push {
+      branch = "^iac/.*"
+    }
+  }
+
+  filename = "infra/cloudbuild-iac.yaml"
+}
+
+# Trigger for infrastructure tags like infra-*
+resource "google_cloudbuild_trigger" "iac-tag-trigger" {
+  provider = google-beta
+  project  = local.project_id
+  location = local.region
+  name     = "iac-tag-trigger"
+
+  service_account = "projects/${local.project_id}/serviceAccounts/terraform-sa@${local.project_id}.iam.gserviceaccount.com"
+
+  repository_event_config {
+    repository = google_cloudbuildv2_repository.picca_repository.id
+    push {
+      tag = "^infra-.*"
+    }
+  }
+
+  filename = "infra/cloudbuild-iac.yaml"
+}

--- a/infra/cloudbuild-iac.yaml
+++ b/infra/cloudbuild-iac.yaml
@@ -1,0 +1,35 @@
+# cloudbuild-iac.yaml
+
+substitutions:
+  _PROJECT: 'picca-dev-464810'
+  _REGION: 'asia-northeast1'
+
+steps:
+  - id: 'tf-init'
+    name: 'hashicorp/terraform:1.8'
+    entrypoint: 'terraform'
+    args: ['init', '-input=false']
+    dir: 'infra'
+
+  - id: 'tf-plan'
+    name: 'hashicorp/terraform:1.8'
+    entrypoint: 'terraform'
+    args:
+      - 'plan'
+      - '-input=false'
+      - '-out=tfplan'
+      - "-var=project=$_PROJECT"
+      - "-var=region=$_REGION"
+    dir: 'infra'
+
+  - id: 'tf-apply'
+    name: 'hashicorp/terraform:1.8'
+    entrypoint: 'terraform'
+    args:
+      - 'apply'
+      - '-auto-approve'
+      - 'tfplan'
+    dir: 'infra'
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- move `cloudbuild-iac.yaml` under infra directory
- expand project/region substitutions correctly in Terraform steps
- update branch and tag triggers to reference `infra/cloudbuild-iac.yaml`

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688986d30d18832ab8d15752be4ceefe