### PR TITLE
Harden Cloud Build region enforcement

### DIFF
--- a/cloudbuild-api-go.yaml
+++ b/cloudbuild-api-go.yaml
@@ -8,7 +8,7 @@ steps:
     entrypoint: 'bash'
     args:
       - -lc
-      - |-
+      - |
         set -euo pipefail
         REGION="${_REGION}"
         if [[ -z "${REGION}" || "${REGION}" == "unset" ]]; then

--- a/cloudbuild-ml-py-prod.yaml
+++ b/cloudbuild-ml-py-prod.yaml
@@ -5,7 +5,6 @@
 substitutions:
   _TAG_NAME: "v0.1.1"
   _MODEL_BUCKET: "picca-models"
-  # _REGION: 'unset' ← この行は不要であれば削除してOKです
 
 options:
   logging: CLOUD_LOGGING_ONLY
@@ -17,7 +16,7 @@ steps:
     entrypoint: 'bash'
     args:
       - -lc
-      - |-
+      - |
         set -euo pipefail
         REGION="${_REGION}"
         if [[ -z "${REGION}" || "${REGION}" == "unset" ]]; then

--- a/cloudbuild-ml-py.yaml
+++ b/cloudbuild-ml-py.yaml
@@ -8,7 +8,7 @@ steps:
     entrypoint: 'bash'
     args:
       - -lc
-      - |-
+      - |
         set -euo pipefail
         REGION="${_REGION}"
         if [[ -z "${REGION}" || "${REGION}" == "unset" ]]; then

--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -7,7 +7,6 @@ availableSecrets:
 
 substitutions:
   _SERVICE: 'picca-prod'
-  _REGION: 'unset'
   _TF_ACTION: 'apply'
 
 images:
@@ -18,6 +17,19 @@ options:
   machineType: UNSPECIFIED
 
 steps:
+  - id: 'guard-region'
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - -lc
+      - |
+        set -euo pipefail
+        REGION="${_REGION}"
+        if [[ -z "${REGION}" || "${REGION}" == "unset" ]]; then
+          echo "ERROR: _REGION must be set in the Cloud Build trigger (e.g., asia-northeast1)." 1>&2
+          exit 1
+        fi
+
   # 1. ユニットテスト
   - id: 'run-unit-tests'
     name: 'node:20'
@@ -47,9 +59,14 @@ steps:
     args:
       - '-c'
       - |
-        gcloud run deploy $_SERVICE \
-          --image gcr.io/$PROJECT_ID/$_SERVICE:$SHORT_SHA \
-          --region $_REGION \
+        set -euo pipefail
+        REGION="${_REGION}"
+        SERVICE="${_SERVICE}"
+        IMAGE="gcr.io/${PROJECT_ID}/${SERVICE}:${SHORT_SHA}"
+
+        gcloud run deploy "${SERVICE}" \
+          --image "${IMAGE}" \
+          --region "${REGION}" \
           --platform managed \
           --no-allow-unauthenticated \
           --set-secrets=DB_PASSWORD=DB_PASSWORD:latest \

--- a/infra/cloudbuild-iac.yaml
+++ b/infra/cloudbuild-iac.yaml
@@ -1,9 +1,19 @@
 # cloudbuild-iac.yaml
 
-substitutions:
-  _REGION: 'unset'
-
 steps:
+  - id: 'guard-region'
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - -lc
+      - |
+        set -euo pipefail
+        REGION="${_REGION}"
+        if [[ -z "${REGION}" || "${REGION}" == "unset" ]]; then
+          echo "ERROR: _REGION must be set in the Cloud Build trigger (e.g., asia-northeast1)." 1>&2
+          exit 1
+        fi
+
   - id: 'tf-init'
     name: 'hashicorp/terraform:1.8'
     entrypoint: 'terraform'

--- a/infra/cloudbuild.yaml
+++ b/infra/cloudbuild.yaml
@@ -6,7 +6,6 @@ availableSecrets:
 substitutions:
   _TF_ACTION: 'plan'
   _SERVICE: 'picca-stg'
-  # _REGION: 'unset' ← この行は不要であれば削除してOKです
 
 images:
   - "gcr.io/$PROJECT_ID/$_SERVICE:$SHORT_SHA"
@@ -22,7 +21,7 @@ steps:
     entrypoint: 'bash'
     args:
       - -lc
-      - |-
+      - |
         set -euo pipefail
         REGION="${_REGION}"
         if [[ -z "${REGION}" || "${REGION}" == "unset" ]]; then


### PR DESCRIPTION
## Summary
- add the shared region guard step to the production and IaC Cloud Build configs and drop the old `_REGION` default
- tighten the production deploy script to populate REGION/SERVICE/IMAGE variables before invoking `gcloud run deploy`
- normalize trailing newlines in other Cloud Build configs for consistent formatting

## Testing
- not run (config change only)

------
https://chatgpt.com/codex/tasks/task_e_68ce27a5426c832abfc33557a442bb9e