### PR TITLE
fix(build): sanitize substitutions, unify backend, gate IaC, add CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Guard Cloud Build substitutions
+        run: |
+          set -euo pipefail
+          ALLOW='PROJECT_ID|SHORT_SHA|COMMIT_SHA|BUILD_ID|REPO_NAME|BRANCH_NAME|TAG_NAME|REVISION_ID|TRIGGER_NAME'
+          PATTERN='(?<!\$)\$(?!('"$ALLOW"')\b)[A-Z][A-Z0-9_]*\b|(?<!\$)\$\{(?!('"$ALLOW"')\})([A-Z][A-Z0-9_]*)\}'
+          files=$(git ls-files '*cloudbuild*.yaml' 'infra/*.yaml' || true)
+          if [ -n "$files" ] && (echo "$files" | xargs -r grep -nP "$PATTERN"); then
+            echo 'Found raw $VAR tokens not in allow-list. Use $$VAR instead (or _SUBST in substitutions:).' >&2
+            exit 1
+          fi
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/cloudbuild-ml-py-prod.yaml
+++ b/cloudbuild-ml-py-prod.yaml
@@ -1,4 +1,4 @@
-﻿# ===== Picca ML PY: prod build & deploy & smoke =====
+# ===== Picca ML PY: prod build & deploy & smoke =====
 # Substitutions: _REGION, _TAG_NAME, _MODEL_BUCKET
 # Example: --substitutions="_REGION=YOUR_REGION,_TAG_NAME=v0.1.1,_MODEL_BUCKET=picca-models"
 
@@ -111,7 +111,8 @@ steps:
             echo "Smoke OK"
             exit 0
           fi
-          [ "$i" -eq 5 ] && { echo "predict failed with HTTP $code"; curl -i "${AUTH_HDR[@]}" -H "Content-Type: application/json" -X POST "$$URL/predict" --data-binary "$body" || true; exit 1; }
+          [ "$i" -eq 5 ] && { echo "predict failed with HTTP $code"; curl -i "${AUTH_HDR[@]}" -H "Content-Type: application/json" \
+            -X POST "$$URL/predict" --data-binary "$body" || true; exit 1; }
           sleep 4
         done
 

--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -24,35 +24,32 @@ steps:
       - -lc
       - |
         set -euo pipefail
-        region="${_REGION}"
+        region="${_REGION:-}"
         if [[ -z "${region}" || "${region}" == "unset" ]]; then
           echo "ERROR: _REGION must be set in the Cloud Build trigger (e.g., asia-northeast1)." 1>&2
           exit 1
         fi
 
-  # 1. ユニットテスト
   - id: 'run-unit-tests'
     name: 'node:20'
     entrypoint: 'bash'
-    secretEnv:
-      - 'DB_PASSWORD'
+    secretEnv: ['DB_PASSWORD']
     args:
-      - '-c'
+      - -lc
       - |
-        echo "Running tests with DB_PASSWORD=$$DB_PASSWORD"
-        npm ci && npm test -- --ci
+        set -euo pipefail
+        echo "Running tests..."
+        npm ci
+        npm test -- --ci
 
-  # 2. Docker ビルド＆プッシュ
-  - id: 'build-and-push-image'
+  - id: 'build-image'
     name: 'gcr.io/cloud-builders/docker'
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        docker build -t gcr.io/$PROJECT_ID/$_SERVICE:$SHORT_SHA .
-        docker push gcr.io/$PROJECT_ID/$_SERVICE:$SHORT_SHA
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/$_SERVICE:$SHORT_SHA', '.']
 
-  # 3. Cloud Run 本番デプロイ
+  - id: 'push-image'
+    name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/$PROJECT_ID/$_SERVICE:$SHORT_SHA']
+
   - id: 'deploy-to-cloud-run'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
@@ -62,13 +59,11 @@ steps:
         set -euo pipefail
         region="${_REGION}"
         service="${_SERVICE}"
-        service_override="$(printenv SERVICE || true)"
-        if [ -n "${service_override}" ]; then
-          service="${service_override}"
+        if [[ -n "$${SERVICE:-}" ]]; then
+          service="$${SERVICE}"
         fi
-        image_override="$(printenv IMAGE || true)"
-        if [ -n "${image_override}" ]; then
-          image="${image_override}"
+        if [[ -n "$${IMAGE:-}" ]]; then
+          image="$${IMAGE}"
         else
           image="gcr.io/${PROJECT_ID}/${service}:${SHORT_SHA}"
         fi
@@ -81,47 +76,59 @@ steps:
           --set-secrets=DB_PASSWORD=DB_PASSWORD:latest \
           --quiet
 
-  # 4. Terraform 初期化
-  - id: 'write-backend-config'
+  - id: 'gen-backend-hcl'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:
       - -lc
       - |
         set -euo pipefail
-        bucket="${_TF_BACKEND_BUCKET:-${TF_BACKEND_BUCKET:-}}"
-        prefix="${_TF_BACKEND_PREFIX:-${TF_BACKEND_PREFIX:-terraform/state}}"
-        impersonate_sa="${_TF_BACKEND_IMPERSONATE_SA:-${TF_BACKEND_IMPERSONATE_SA:-}}"
-
-        if [[ -z "${bucket}" ]]; then
-          echo "ERROR: Provide _TF_BACKEND_BUCKET (or legacy TF_BACKEND_BUCKET) in the trigger substitutions." 1>&2
+        BUCKET="${_TF_BACKEND_BUCKET:-${TF_BACKEND_BUCKET:-}}"
+        if [[ -z "$$BUCKET" ]]; then
+          echo "ERROR: Provide _TF_BACKEND_BUCKET (or TF_BACKEND_BUCKET)." 1>&2
           exit 1
         fi
-
+        PREFIX="${_TFSTATE_PREFIX:-${TFSTATE_PREFIX:-infra/state}}"
+        IMPERSONATE="${_TF_BACKEND_IMPERSONATE_SA:-${TF_BACKEND_IMPERSONATE_SA:-}}"
         {
-          printf 'bucket = "%s"\n' "${bucket}"
-          printf 'prefix = "%s"\n' "${prefix}"
-          if [[ -n "${impersonate_sa}" ]]; then
-            printf 'impersonate_service_account = "%s"\n' "${impersonate_sa}"
+          printf 'bucket = "%s"\n' "$$BUCKET"
+          printf 'prefix = "%s"\n' "$$PREFIX"
+          if [[ -n "$$IMPERSONATE" ]]; then
+            printf 'impersonate_service_account = "%s"\n' "$$IMPERSONATE"
           fi
         } > infra/backend.hcl
+        echo "[ok] wrote infra/backend.hcl -> bucket=$$BUCKET, prefix=$$PREFIX"
 
   - id: 'tf-init'
     name: 'hashicorp/terraform:1.8'
-    entrypoint: 'terraform'
+    entrypoint: 'bash'
     args:
-      - '-chdir=infra'
-      - 'init'
-      - '-backend-config=backend.hcl'
+      - -lc
+      - |
+        set -euo pipefail
+        action="${_TF_ACTION:-plan}"
+        [[ "${action}" =~ ^(plan|apply)$ ]] || { echo "[skip] tf-init"; exit 0; }
+        terraform -chdir=infra init -backend-config=backend.hcl
 
-  # 5. Terraform apply
+  - id: 'tf-plan'
+    name: 'hashicorp/terraform:1.8'
+    entrypoint: 'bash'
+    args:
+      - -lc
+      - |
+        set -euo pipefail
+        action="${_TF_ACTION:-plan}"
+        [[ "${action}" =~ ^(plan|apply)$ ]] || { echo "[skip] tf-plan"; exit 0; }
+        terraform -chdir=infra plan -no-color -input=false -out=plan.tfout \
+          -var="project=${PROJECT_ID}" -var="region=${_REGION}"
+
   - id: 'tf-apply'
     name: 'hashicorp/terraform:1.8'
-    entrypoint: 'terraform'
+    entrypoint: 'bash'
     args:
-      - '-chdir=infra'
-      - 'apply'
-      - '-var=project=${PROJECT_ID}'
-      - '-var=region=${_REGION}'
-      - '-auto-approve'
-
+      - -lc
+      - |
+        set -euo pipefail
+        action="${_TF_ACTION:-plan}"
+        [[ "${action}" == "apply" ]] || { echo "[skip] tf-apply"; exit 0; }
+        terraform -chdir=infra apply -auto-approve plan.tfout

--- a/infra/cloudbuild-iac.yaml
+++ b/infra/cloudbuild-iac.yaml
@@ -1,5 +1,7 @@
+options:
+  logging: CLOUD_LOGGING_ONLY
+
 steps:
-  # 0) _REGION ガード
   - id: 'guard-region'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
@@ -13,7 +15,6 @@ steps:
           exit 1
         fi
 
-  # 1) backend.hcl 生成（_TF_BACKEND_BUCKET 必須、$$ で置換回避）
   - id: 'gen-backend-hcl'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
@@ -21,46 +22,52 @@ steps:
       - -lc
       - |
         set -euo pipefail
-        bucket="${_TF_BACKEND_BUCKET:-${TF_BACKEND_BUCKET:-}}"
-        prefix="${_TFSTATE_PREFIX:-${TFSTATE_PREFIX:-terraform/state}}"
-        impersonate_sa="${_TF_BACKEND_IMPERSONATE_SA:-${TF_BACKEND_IMPERSONATE_SA:-}}"
-
-        if [[ -z "$$bucket" ]]; then
-          echo "ERROR: Provide _TF_BACKEND_BUCKET (or legacy TF_BACKEND_BUCKET) in the trigger substitutions." 1>&2
+        BUCKET="${_TF_BACKEND_BUCKET:-${TF_BACKEND_BUCKET:-}}"
+        if [[ -z "$$BUCKET" ]]; then
+          echo "ERROR: Provide _TF_BACKEND_BUCKET (or TF_BACKEND_BUCKET)." 1>&2
           exit 1
         fi
-
+        PREFIX="${_TFSTATE_PREFIX:-${TFSTATE_PREFIX:-infra/state}}"
+        IMPERSONATE="${_TF_BACKEND_IMPERSONATE_SA:-${TF_BACKEND_IMPERSONATE_SA:-}}"
         {
-          printf 'bucket = "%s"\n' "$$bucket"
-          printf 'prefix = "%s"\n' "$$prefix"
-          if [[ -n "$$impersonate_sa" ]]; then
-            printf 'impersonate_service_account = "%s"\n' "$$impersonate_sa"
+          printf 'bucket = "%s"\n' "$$BUCKET"
+          printf 'prefix = "%s"\n' "$$PREFIX"
+          if [[ -n "$$IMPERSONATE" ]]; then
+            printf 'impersonate_service_account = "%s"\n' "$$IMPERSONATE"
           fi
         } > infra/backend.hcl
+        echo "[ok] wrote infra/backend.hcl -> bucket=$$BUCKET, prefix=$$PREFIX"
 
-  # 2) terraform init
   - id: 'tf-init'
     name: 'hashicorp/terraform:1.8'
-    entrypoint: 'terraform'
-    args: ['-chdir=infra', 'init', '-backend-config=backend.hcl']
+    entrypoint: 'bash'
+    args:
+      - -lc
+      - |
+        set -euo pipefail
+        action="${_TF_ACTION:-plan}"
+        [[ "${action}" =~ ^(plan|apply)$ ]] || { echo "[skip] tf-init"; exit 0; }
+        terraform -chdir=infra init -backend-config=backend.hcl
 
-  # 3) terraform plan
   - id: 'tf-plan'
     name: 'hashicorp/terraform:1.8'
-    entrypoint: 'terraform'
+    entrypoint: 'bash'
     args:
-      - '-chdir=infra'
-      - 'plan'
-      - '-input=false'
-      - '-out=tfplan'
-      - "-var=project=${PROJECT_ID}"
-      - "-var=region=${_REGION}"
+      - -lc
+      - |
+        set -euo pipefail
+        action="${_TF_ACTION:-plan}"
+        [[ "${action}" =~ ^(plan|apply)$ ]] || { echo "[skip] tf-plan"; exit 0; }
+        terraform -chdir=infra plan -no-color -input=false -out=plan.tfout \
+          -var="project=${PROJECT_ID}" -var="region=${_REGION}"
 
-  # 4) terraform apply
   - id: 'tf-apply'
     name: 'hashicorp/terraform:1.8'
-    entrypoint: 'terraform'
-    args: ['-chdir=infra', 'apply', '-auto-approve', 'tfplan']
-
-options:
-  logging: CLOUD_LOGGING_ONLY
+    entrypoint: 'bash'
+    args:
+      - -lc
+      - |
+        set -euo pipefail
+        action="${_TF_ACTION:-plan}"
+        [[ "${action}" == "apply" ]] || { echo "[skip] tf-apply"; exit 0; }
+        terraform -chdir=infra apply -auto-approve plan.tfout

--- a/infra/cloudbuild.yaml
+++ b/infra/cloudbuild.yaml
@@ -4,8 +4,8 @@ availableSecrets:
       env: "DB_PASSWORD"
 
 substitutions:
-  _TF_ACTION: 'plan'       # plan|apply|skip（skip なら IaC を飛ばす）
-  _SERVICE: 'picca-stg'    # デフォルトサービス名（SERVICE/IMAGE env で上書き可）
+  _SERVICE: 'picca-stg'
+  _TF_ACTION: 'plan'
 
 images:
   - "gcr.io/$PROJECT_ID/$_SERVICE:$SHORT_SHA"
@@ -15,7 +15,6 @@ options:
   machineType: UNSPECIFIED
 
 steps:
-  # 0) _REGION は必須
   - id: 'guard-region'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
@@ -29,19 +28,17 @@ steps:
           exit 1
         fi
 
-  # 1) ユニットテスト
   - id: 'install-and-test'
     name: 'node:20'
     entrypoint: 'bash'
     secretEnv: ['DB_PASSWORD']
     args:
-      - -c
+      - -lc
       - |
         set -euo pipefail
         npm ci
         npm test -- --ci
 
-  # 2) Docker build & push
   - id: 'build-image'
     name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 'gcr.io/$PROJECT_ID/$_SERVICE:$SHORT_SHA', '.']
@@ -50,7 +47,6 @@ steps:
     name: 'gcr.io/cloud-builders/docker'
     args: ['push', 'gcr.io/$PROJECT_ID/$_SERVICE:$SHORT_SHA']
 
-  # 3) Cloud Run deploy
   - id: 'deploy-to-cloud-run'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
@@ -60,8 +56,14 @@ steps:
         set -euo pipefail
         region="${_REGION}"
         service="${_SERVICE}"
-        if [[ -n "${SERVICE:-}" ]]; then service="${SERVICE}"; fi
-        if [[ -n "${IMAGE:-}" ]];  then image="${IMAGE}"; else image="gcr.io/$PROJECT_ID/${service}:$SHORT_SHA"; fi
+        if [[ -n "$${SERVICE:-}" ]]; then
+          service="$${SERVICE}"
+        fi
+        if [[ -n "$${IMAGE:-}" ]]; then
+          image="$${IMAGE}"
+        else
+          image="gcr.io/$PROJECT_ID/${service}:$SHORT_SHA"
+        fi
 
         gcloud run deploy "${service}" \
           --image "${image}" \
@@ -71,7 +73,6 @@ steps:
           --allow-unauthenticated \
           --quiet
 
-  # 3.5) Terraform backend.hcl 生成（Cloud Build 置換を回避するため $$ を使用）
   - id: 'gen-backend-hcl'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
@@ -81,14 +82,20 @@ steps:
         set -euo pipefail
         BUCKET="${_TF_BACKEND_BUCKET:-${TF_BACKEND_BUCKET:-}}"
         if [[ -z "$$BUCKET" ]]; then
-          echo "ERROR: Provide _TF_BACKEND_BUCKET in trigger substitutions, or export TF_BACKEND_BUCKET." 1>&2
+          echo "ERROR: Provide _TF_BACKEND_BUCKET (or TF_BACKEND_BUCKET)." 1>&2
           exit 1
         fi
         PREFIX="${_TFSTATE_PREFIX:-${TFSTATE_PREFIX:-infra/state}}"
-        printf 'bucket = "%s"\nprefix = "%s"\n' "$$BUCKET" "$$PREFIX" > infra/backend.hcl
+        IMPERSONATE="${_TF_BACKEND_IMPERSONATE_SA:-${TF_BACKEND_IMPERSONATE_SA:-}}"
+        {
+          printf 'bucket = "%s"\n' "$$BUCKET"
+          printf 'prefix = "%s"\n' "$$PREFIX"
+          if [[ -n "$$IMPERSONATE" ]]; then
+            printf 'impersonate_service_account = "%s"\n' "$$IMPERSONATE"
+          fi
+        } > infra/backend.hcl
         echo "[ok] wrote infra/backend.hcl -> bucket=$$BUCKET, prefix=$$PREFIX"
 
-  # 4) Terraform init（_TF_ACTION=skip のときはスキップ）
   - id: 'tf-init'
     name: 'hashicorp/terraform:1.8'
     entrypoint: 'bash'
@@ -96,10 +103,10 @@ steps:
       - -lc
       - |
         set -euo pipefail
-        [[ "${_TF_ACTION:-plan}" =~ ^(plan|apply)$ ]] || { echo "[skip] tf-init"; exit 0; }
+        action="${_TF_ACTION:-plan}"
+        [[ "${action}" =~ ^(plan|apply)$ ]] || { echo "[skip] tf-init"; exit 0; }
         terraform -chdir=infra init -backend-config=backend.hcl
 
-  # 5) Terraform plan（_TF_ACTION=apply でも plan を作成）
   - id: 'tf-plan'
     name: 'hashicorp/terraform:1.8'
     entrypoint: 'bash'
@@ -107,11 +114,11 @@ steps:
       - -lc
       - |
         set -euo pipefail
-        [[ "${_TF_ACTION:-plan}" =~ ^(plan|apply)$ ]] || { echo "[skip] tf-plan"; exit 0; }
+        action="${_TF_ACTION:-plan}"
+        [[ "${action}" =~ ^(plan|apply)$ ]] || { echo "[skip] tf-plan"; exit 0; }
         terraform -chdir=infra plan -no-color -input=false -out=plan.tfout \
           -var="project=${PROJECT_ID}" -var="region=${_REGION}"
 
-  # 6) Terraform apply（_TF_ACTION=apply のときのみ実行）
   - id: 'tf-apply'
     name: 'hashicorp/terraform:1.8'
     entrypoint: 'bash'
@@ -119,5 +126,6 @@ steps:
       - -lc
       - |
         set -euo pipefail
-        [[ "${_TF_ACTION:-plan}" == "apply" ]] || { echo "[skip] tf-apply"; exit 0; }
+        action="${_TF_ACTION:-plan}"
+        [[ "${action}" == "apply" ]] || { echo "[skip] tf-apply"; exit 0; }
         terraform -chdir=infra apply -auto-approve plan.tfout


### PR DESCRIPTION
## Summary
- sanitize the main Cloud Build workflow by escaping runtime variables, unifying backend.hcl generation, and gating Terraform actions behind `_TF_ACTION`
- align the standalone IaC and production Cloud Build pipelines with the same backend writer and gating semantics, plus normalize the ML prod pipeline formatting
- add a CI safeguard that blocks commits introducing unescaped Cloud Build substitutions

## Testing
- `bash <<'EOF'
set -euo pipefail
ALLOW='PROJECT_ID|SHORT_SHA|COMMIT_SHA|BUILD_ID|REPO_NAME|BRANCH_NAME|TAG_NAME|REVISION_ID|TRIGGER_NAME'
PATTERN='(?<!\$)\$(?!('"$ALLOW"')\b)[A-Z][A-Z0-9_]*\b|(?<!\$)\$\{(?!('"$ALLOW"')\})([A-Z][A-Z0-9_]*)\}'
files=$(git ls-files '*cloudbuild*.yaml' 'infra/*.yaml' || true)
if [ -n "$files" ] && (echo "$files" | xargs -r grep -nP "$PATTERN"); then
  echo 'Found raw $VAR tokens not in allow-list. Use $$VAR instead (or _SUBST in substitutions:).' >&2
  exit 1
fi
EOF`

## Manual steps
- Cloud Build Console → each trigger → Substitutions を次のみに設定
  - 必須: `_REGION=asia-northeast1`
  - main 用: `_TF_BACKEND_BUCKET=terraform-state-picca-dev-464810`, `_TFSTATE_PREFIX=terraform/state`
  - 任意: `_TF_ACTION=plan|apply|skip`, `_SERVICE=picca-stg`, `_TAG_NAME=…`, `_MODEL_BUCKET=…`, `_MODEL_URI=…`, `_MODEL_SHA256=…`
  - 禁止: `SERVICE/BUCKET/PREFIX/REGION/IMAGE` のような先頭 `_` なしキー (存在したら削除)
- Cloud Build のサービスアカウントに state バケットへの `roles/storage.objectAdmin` を付与

------
https://chatgpt.com/codex/tasks/task_e_68d22d330eb4832a88e1c999cbd4ecf5