### PR TITLE
Add healthz endpoint

### DIFF
--- a/services/api-go/health.go
+++ b/services/api-go/health.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+// /healthz: simple liveness. GET/HEAD -> 200, others -> 405.
+func healthz(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	case http.MethodHead:
+		w.WriteHeader(http.StatusOK)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func init() {
+	http.HandleFunc("/healthz", healthz)
+	log.Printf("mounted /healthz")
+}


### PR DESCRIPTION
## Summary
- add a new /healthz endpoint for liveness checks in the Go API

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d52d4fbb64832aa0524d3ab86d2d35