### PR TITLE
Register health endpoint on gin router

### DIFF
--- a/services/api-go/main.go
+++ b/services/api-go/main.go
@@ -408,12 +408,7 @@ func main() {
 	mountDemo(r)
 	mountAPI(r)
 
-	r.GET("/healthz", func(c *gin.Context) {
-		c.String(200, "ok")
-	})
-	r.HEAD("/healthz", func(c *gin.Context) {
-		c.Status(200)
-	})
+	r.Any("/healthz", gin.WrapF(healthz))
 	r.GET("/readyz", func(c *gin.Context) {
 		c.String(200, "ready")
 	})


### PR DESCRIPTION
## Summary
- register the existing /healthz handler on the gin router so the custom mux serves it

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d53176ecd4832a979e56dd7d3f7c10