### PR TITLE
Register /healthz on gin engine

### DIFF
--- a/services/api-go/main.go
+++ b/services/api-go/main.go
@@ -404,11 +404,18 @@ func explainHandler(c *gin.Context) {
 func main() {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
+	r.GET("/healthz", gin.WrapF(healthz))
+	r.HEAD("/healthz", gin.WrapF(healthz))
+	log.Println("gin: mounted /healthz on engine")
+	for _, ri := range r.Routes() {
+		if ri.Path == "/healthz" {
+			log.Printf("gin route %s %s", ri.Method, ri.Path)
+		}
+	}
 
 	mountDemo(r)
 	mountAPI(r)
 
-	r.Any("/healthz", gin.WrapF(healthz))
 	r.GET("/readyz", func(c *gin.Context) {
 		c.String(200, "ready")
 	})


### PR DESCRIPTION
## Summary
- register GET and HEAD /healthz handlers directly on the Gin engine used in production
- log the mounted /healthz routes at startup for easier verification

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d53694bf80832a99ebd4c73374d13d