### PR TITLE
hotfix(api): expose /livez (public liveness) at outer mux using healthz handler

### DIFF
--- a/services/api-go/main.go
+++ b/services/api-go/main.go
@@ -449,12 +449,15 @@ func main() {
 	}
 	addr := ":" + port
 
-	mux := http.NewServeMux()
-	mux.Handle("/", r)
-	mux.HandleFunc("/healthz", healthz)
-	mux.HandleFunc("/healthz/", healthz)
+        mux := http.NewServeMux()
+        mux.Handle("/", r)
+        mux.HandleFunc("/healthz", healthz)
+        mux.HandleFunc("/healthz/", healthz)
+        mux.HandleFunc("/livez", healthz)
+        mux.HandleFunc("/livez/", healthz)
 
-	finalHandler := withHealthz(mux)
+        finalHandler := withHealthz(mux)
+        log.Printf("mux: /livez mounted (alias of /healthz)")
 	log.Printf("server ready on %s; handler=%T (final mux with /healthz)", addr, finalHandler)
 
 	srv := &http.Server{


### PR DESCRIPTION
## Summary
- add /livez and /livez/ aliases at the outer HTTP mux, reusing the existing healthz handler
- log that the liveness alias is mounted during startup for visibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d54df28610832a9515a239210dbd25